### PR TITLE
This commit fixes several issues with split-archive creation

### DIFF
--- a/archiver/archive.py
+++ b/archiver/archive.py
@@ -41,26 +41,21 @@ def create_archive(source_path, destination_path, threads=None, encryption_keys=
 
     source_name = source_path.name
 
-    logging.info(f"Start creating archive for: {helpers.get_absolute_path_string(source_path)}")
-
     if not threads:
         threads = 1
 
+    logging.info(f"Start creating archive for: {helpers.get_absolute_path_string(source_path)}")
+
+    # Create destination folder if nonexistent or overwrite if --force option used
+    helpers.handle_destination_directory_creation(destination_path, force)
+
+    logging.info("Create and write hash list...")
+    create_filelist_and_hashes(source_path, destination_path, splitting, threads)
+
     if splitting:
-        create_split_archive(source_path, destination_path, source_name, int(splitting), threads, encryption_keys, compression, remove_unencrypted, work_dir, force)
+        create_split_archive(source_path, destination_path, threads, encryption_keys, compression, work_dir)
     else:
-        # Create destination folder if nonexistent or overwrite if --force option used
-        helpers.handle_destination_directory_creation(destination_path, force)
-
-        logging.info("Create and write hash list...")
-        create_file_listing_hash(source_path, destination_path, source_name, max_workers=threads)
-
-        logging.info(f"Create tar archive in {destination_path}...")
-        create_tar_archive(source_path, destination_path, source_name, work_dir)
-        logging.info(f"Generating hash for tar archive {destination_path}...")
-        create_and_write_archive_hash(destination_path, source_name)
-        logging.info(f"Generating archive listing for tar archive {destination_path}...")
-        create_archive_listing(destination_path, source_name)
+        _process_part(source_path, destination_path, work_dir, source_name)
 
         logging.info("Starting compression of tar archive...")
         compress_using_lzip(destination_path, source_name, threads, compression)
@@ -74,13 +69,11 @@ def create_archive(source_path, destination_path, threads=None, encryption_keys=
     logging.info(f"Archive created: {helpers.get_absolute_path_string(destination_path)}")
 
 
-def create_split_archive(source_path, destination_path, source_name, splitting, threads, encryption_keys, compression, remove_unencrypted, work_dir=None, force=False):
+def create_split_archive(source_path, destination_path, threads, encryption_keys, compression, work_dir=None):
     logging.info("Start creation of split archive")
 
     if not threads:
         threads = 1
-
-    create_filelist_and_hashs(source_path, destination_path, splitting, threads, force)
 
     create_tar_archives_and_listings(source_path, destination_path, work_dir, workers=threads)
 
@@ -90,8 +83,7 @@ def create_split_archive(source_path, destination_path, source_name, splitting, 
         do_encryption(destination_path, encryption_keys, threads)
 
 
-def create_filelist_and_hashs(source_path, destination_path, split_size, threads, force=False):
-    helpers.handle_destination_directory_creation(destination_path, force)
+def create_filelist_and_hashes(source_path, destination_path, split_size, threads):
 
     if split_size:
         logging.info(f"Using a split size of {split_size} bytes ({split_size/1024**3:.3f}GB).")
@@ -103,8 +95,7 @@ def create_filelist_and_hashs(source_path, destination_path, split_size, threads
             f.write(f"{nr_parts}\n")
     else:
         create_file_listing_hash(source_path, destination_path,
-                                 source_path.name, archive_list=None,
-                                 max_workers=threads)
+                                 source_path.name, max_workers=threads)
 
 
 def create_file_listing_hash_split_archives(source_path, destination_path, split_size, threads):
@@ -117,13 +108,13 @@ def create_file_listing_hash_split_archives(source_path, destination_path, split
         logging.info(f"Generate file listings for part {index + 1}")
         source_part_name = f"{source_name}.part{index + 1}"
         create_file_listing_hash(source_path, destination_path,
-                                         source_part_name, archive,
-                                         max_workers=threads)
+                                 source_part_name, archive[0], archive[1],
+                                 max_workers=threads)
         nr_parts += 1
     return nr_parts
 
 
-def create_file_listing_hash(source_path_root, destination_path, source_name, archive_list=None, max_workers=1):
+def create_file_listing_hash(source_path_root, destination_path, source_name, archive_list=None, listing=None, max_workers=1):
     if archive_list:
         paths_to_hash_list = archive_list
     else:
@@ -131,7 +122,6 @@ def create_file_listing_hash(source_path_root, destination_path, source_name, ar
 
     hashes = sorted(hashes_for_path_list(paths_to_hash_list, source_path_root, max_workers), key=lambda p: p[0])
     hash_file_path = destination_path.joinpath(source_name + ".md5")
-
 
     logging.info(f"Writing file hash list to {hash_file_path}")
     with open(hash_file_path, "a") as hash_file:
@@ -145,9 +135,22 @@ def create_file_listing_hash(source_path_root, destination_path, source_name, ar
             file_hash = line[1]
             hash_file.write(f"{hash_prefix}{file_hash} {file_path}\n")
 
+    listing_file_path = destination_path.joinpath(source_name + ".lst")
+    logging.info(f"Writing complete file listing to {listing_file_path}")
+    if not listing:
+        listing = helpers.get_files_in_folder(source_path_root, include_dirs=True)
+    listing = [_.relative_to(source_path_root.parent).as_posix() for _ in listing]
+    with open(listing_file_path, "a") as listing_file:
+        for file_path in listing:
+            prefix = ''
+            if '\n' in file_path or '\\' in file_path:
+                file_path = file_path.replace('\\', '\\\\').replace('\n', '\\n') # escaping new lines in filenames...
+                prefix = '\\'
+            listing_file.write(f"{prefix}{file_path}\n")
+
 
 def hashes_for_path_list(path_list, source_path_root, max_workers=1):
-    files = [path for path in path_list if not path.is_dir()]
+    files = [path for path in path_list if (not path.is_dir()) or path.is_symlink()]
 
     for path in path_list:
         if path.is_dir():
@@ -157,13 +160,14 @@ def hashes_for_path_list(path_list, source_path_root, max_workers=1):
 
 
 def _process_part(source_path, destination_path, work_dir, source_part_name):
-    archive_list = [ source_path.parent / f for f in helpers.read_hash_file(destination_path / f"{source_part_name}.md5").keys()]
+    #archive_list = [ source_path.parent / f for f in helpers.read_hash_file(destination_path / f"{source_part_name}.md5").keys()]
+    archive_list = [source_path.parent / f for f in helpers.read_file_listing(destination_path / f"{source_part_name}.lst")]
 
-    logging.info(f"Create tar archive for {source_part_name}")
+    logging.info(f"Create tar archive for {source_part_name} in {destination_path} ...")
     create_tar_archive(source_path, destination_path, source_part_name, archive_list, work_dir)
-    logging.info(f"Generating hash for tar archive {source_part_name}")
+    logging.info(f"Generating hash for tar archive {source_part_name} in {destination_path}")
     create_and_write_archive_hash(destination_path, source_part_name)
-    logging.info(f"Generating tar archive listing for {source_part_name}")
+    logging.info(f"Generating tar archive listing for tar archive {source_part_name} in {destination_path}")
     create_archive_listing(destination_path, source_part_name)
 
 
@@ -171,18 +175,18 @@ def create_tar_archives_and_listings(source_path, destination_path, work_dir, pa
     source_name = source_path.name
 
     if parts:
-        part_hashes = [destination_path / f"{source_name}.part{part}.md5" for part in parts]
+        part_listings = [destination_path / f"{source_name}.part{part}.lst" for part in parts]
     else:
-        single_part_md5 = destination_path /f'{source_name}.md5'
-        if single_part_md5.exists():
-            part_hashes = [single_part_md5]
+        single_part_listing = destination_path /f'{source_name}.lst'
+        if single_part_listing.exists():
+            part_listings = [single_part_listing]
         else:
-            part_hashes = helpers.list_files_matching_name(destination_path, re.compile(rf'{source_name}\.part[0-9]+\.md5'))
+            part_listings = helpers.list_files_matching_name(destination_path, re.compile(rf'{source_name}\.part[0-9]+\.lst'))
 
-        if not part_hashes:
-            helpers.terminate_with_message(f"No {source_name}.md5 or files matching {source_name}.part[0-9]*.md5 found in {destination_path}")
+        if not part_listings:
+            helpers.terminate_with_message(f"No {source_name}.lst or files matching {source_name}.part[0-9]+.list found in {destination_path}")
 
-    part_names = [os.path.splitext(p.name)[0] for p in helpers.sort_paths_with_part(part_hashes)]
+    part_names = [os.path.splitext(p.name)[0] for p in helpers.sort_paths_with_part(part_listings)]
 
     logging.info(f"Creating tar archives and listings for {','.join(part_names)} using {workers} workers.")
     helpers.exec_parallel(_process_part, part_names, lambda p: (source_path, destination_path, work_dir, p), workers)
@@ -211,7 +215,7 @@ def create_tar_archive_from_list(source_path, archive_list, destination_file_pat
         with open(tmp_file_path, "w") as tmp_file:
             tmp_file.write("\0".join(files_string_list))
 
-        helpers.run_shell_cmd(["tar", "--posix", "-cf", destination_file_path, "-C", source_path_parent, "--null", "--files-from", tmp_file_path])
+        helpers.run_shell_cmd(["tar", "--posix", "-cf", destination_file_path, "-C", source_path_parent, "--null", "--no-recursion", "--files-from", tmp_file_path])
 
 
 def create_archive_listing(destination_path, source_name):

--- a/archiver/helpers.py
+++ b/archiver/helpers.py
@@ -173,7 +173,7 @@ def get_files_in_folder(folder_path, include_dirs=False):
                 if include_dirs:
                     listing.append(abs_dir)
                 dirs_.append(dir)
-        dirs = dirs_
+        dirs[:] = dirs_
 
     return listing
 

--- a/archiver/main.py
+++ b/archiver/main.py
@@ -11,7 +11,7 @@ import multiprocessing_logging
 
 from archiver import helpers, __version__
 from archiver.archive import create_archive, encrypt_existing_archive, \
-    create_filelist_and_hashs, \
+    create_filelist_and_hashes, \
     create_tar_archives_and_listings, compress_and_hash
 from archiver.constants import DEFAULT_COMPRESSION_LEVEL
 from archiver.extract import extract_archive, decrypt_existing_archive
@@ -103,7 +103,7 @@ def parse_arguments(args):
     parser_create = subparsers.add_parser("create", help="Create archives step-by-step (optimization possibilities for large split archives)")
     subparser_create = parser_create.add_subparsers(help="Available subcommands", required=True, dest="create_command")
 
-    parser_create_filelist = subparser_create.add_parser("filelist", help="create list and hashs of all files to be archived", parents=[archive_parent_parser])
+    parser_create_filelist = subparser_create.add_parser("filelist", help="create list and hashes of all files to be archived", parents=[archive_parent_parser])
     parser_create_filelist.add_argument("--part-size", type=str, help=part_size_help)
     parser_create_filelist.add_argument("-f", "--force", action="store_true", default=False, help=force_help)
     parser_create_filelist.set_defaults(func=handle_create_filelist)
@@ -211,7 +211,9 @@ def handle_create_filelist(args):
         except Exception as error:
             helpers.terminate_with_exception(error)
 
-    create_filelist_and_hashs(source_path, destination_path, bytes_splitting, threads, args.force)
+    # Create destination folder if nonexistent or overwrite if --force option used
+    helpers.handle_destination_directory_creation(destination_path, args.force)
+    create_filelist_and_hashes(source_path, destination_path, bytes_splitting, threads)
 
 
 def handle_create_tar_archive(args):

--- a/archiver/splitter.py
+++ b/archiver/splitter.py
@@ -7,6 +7,7 @@ from . import helpers
 def split_directory(directory_path, max_package_size):
     # all file sizes are in bytes
     current_archive = []
+    current_listing = []
     archive_size = 0
 
     for root, dirs, files in os.walk(directory_path):
@@ -15,15 +16,25 @@ def split_directory(directory_path, max_package_size):
         excluded_dirs = []
 
         for directory in dirs:
-            # if the folder fits into an archive package, the content of the folder not be looked at
+            # if the folder fits into an archive package, the content of the folder will not be looked at
             dir_path = Path(root).joinpath(directory)
+            # treat symlinks to directories as files
+            if dir_path.is_symlink():
+                excluded_dirs.append(directory)
+                files.append(directory)
+                continue
             dir_size = helpers.get_size_of_path(dir_path)
 
             if archive_size + dir_size < max_package_size:
                 current_archive.append(dir_path)
+                current_listing.append(dir_path)
+                current_listing.extend(helpers.get_files_in_folder(dir_path, include_dirs=True))
                 archive_size += dir_size
 
                 excluded_dirs.append(directory)
+            else:
+                current_listing.append(dir_path)
+
             # for creating new package for directory that doesn't fit in current directory
             # See commit: #22d5fb7
 
@@ -39,14 +50,16 @@ def split_directory(directory_path, max_package_size):
 
             if archive_size + file_size < max_package_size:
                 current_archive.append(file_path)
+                current_listing.append(file_path)
                 archive_size += file_size
             elif file_size < max_package_size:
-                yield current_archive
+                yield current_archive, current_listing
 
                 current_archive = [file_path]
+                current_listing = [file_path]
                 archive_size = file_size
             else:
                 raise ValueError(f"File {file_path.as_posix()} with {file_size} bytes "
                                  f"is larger than the maximum package size of {max_package_size} bytes")
 
-    yield current_archive
+    yield current_archive, current_listing

--- a/archiver/splitter.py
+++ b/archiver/splitter.py
@@ -25,15 +25,12 @@ def split_directory(directory_path, max_package_size):
                 continue
             dir_size = helpers.get_size_of_path(dir_path)
 
+            current_listing.append(dir_path)
             if archive_size + dir_size < max_package_size:
                 current_archive.append(dir_path)
-                current_listing.append(dir_path)
                 current_listing.extend(helpers.get_files_in_folder(dir_path, include_dirs=True))
                 archive_size += dir_size
-
                 excluded_dirs.append(directory)
-            else:
-                current_listing.append(dir_path)
 
             # for creating new package for directory that doesn't fit in current directory
             # See commit: #22d5fb7

--- a/tests/features/archiving_helpers.py
+++ b/tests/features/archiving_helpers.py
@@ -10,8 +10,8 @@ UNENCRYPTED_HASH_FILENAMES = [".tar.md5", ".tar.lz.md5"]
 SPLIT_ENCRYPTED_HASH_FILENAMES = [".part1.tar.md5", ".part2.tar.md5", ".part1.tar.lz.md5", ".part2.tar.lz.md5", ".part1.tar.lz.gpg.md5", ".part2.tar.lz.gpg.md5"]
 SPLIT_UNENCRYPTED_HASH_FILENAMES = [".part1.tar.md5", ".part2.tar.md5", ".part1.tar.lz.md5", ".part2.tar.lz.md5"]
 
-ENCRYPTED_LISTING = [".tar.lst", ".tar.lz.md5", ".md5", ".tar.lz.gpg", ".tar.lz.gpg.md5", ".tar.md5"]
-UNENCRYPTED_LISTING = ['.tar.lst', '.tar.lz.md5', '.md5', '.tar.lz', '.tar.md5']
+ENCRYPTED_LISTING = [".lst", ".tar.lst", ".tar.lz.md5", ".md5", ".tar.lz.gpg", ".tar.lz.gpg.md5", ".tar.md5"]
+UNENCRYPTED_LISTING = ['.lst', '.tar.lst', '.tar.lz.md5', '.md5', '.tar.lz', '.tar.md5']
 SPLIT_UNENCRYPTED_LISTINGS = ['.part1.tar.lst', '.part1.tar.lz.md5', '.part1.md5', '.part1.tar.lz', '.part1.tar.md5',
                               '.part2.tar.lst', '.part2.tar.lz.md5', '.part2.md5', '.part2.tar.lz', '.part2.tar.md5']
 SPLIT_ENCRYPTED_LISTINGS = [".part1.tar.lst", ".part1.tar.lz.md5", ".part1.md5", ".part1.tar.lz.gpg", ".part1.tar.lz.gpg.md5", ".part1.tar.md5",

--- a/tests/test-ressources/encrypted-archive-corrupted-deep/test-folder.lst
+++ b/tests/test-ressources/encrypted-archive-corrupted-deep/test-folder.lst
@@ -1,0 +1,4 @@
+test-folder
+test-folder/file1.txt
+test-folder/folder-in-archive
+test-folder/folder-in-archive/file2.txt

--- a/tests/test-ressources/encrypted-archive-corrupted/test-folder.lst
+++ b/tests/test-ressources/encrypted-archive-corrupted/test-folder.lst
@@ -1,0 +1,4 @@
+test-folder
+test-folder/file1.txt
+test-folder/folder-in-archive
+test-folder/folder-in-archive/file2.txt

--- a/tests/test-ressources/encrypted-archive/test-folder.lst
+++ b/tests/test-ressources/encrypted-archive/test-folder.lst
@@ -1,0 +1,4 @@
+test-folder
+test-folder/file1.txt
+test-folder/folder-in-archive
+test-folder/folder-in-archive/file2.txt

--- a/tests/test-ressources/normal-archive-corrupted-deep/test-folder.lst
+++ b/tests/test-ressources/normal-archive-corrupted-deep/test-folder.lst
@@ -1,0 +1,4 @@
+test-folder
+test-folder/file1.txt
+test-folder/folder-in-archive
+test-folder/folder-in-archive/file2.txt

--- a/tests/test-ressources/normal-archive-corrupted/test-folder.lst
+++ b/tests/test-ressources/normal-archive-corrupted/test-folder.lst
@@ -1,0 +1,4 @@
+test-folder
+test-folder/file1.txt
+test-folder/folder-in-archive
+test-folder/folder-in-archive/file2.txt

--- a/tests/test-ressources/normal-archive/test-folder.lst
+++ b/tests/test-ressources/normal-archive/test-folder.lst
@@ -1,0 +1,4 @@
+test-folder
+test-folder/file1.txt
+test-folder/folder-in-archive
+test-folder/folder-in-archive/file2.txt

--- a/tests/test-ressources/split-archive-corrupted/large-folder.part1.lst
+++ b/tests/test-ressources/split-archive-corrupted/large-folder.part1.lst
@@ -1,0 +1,2 @@
+large-folder/subfolder
+large-folder/subfolder/file_c.txt

--- a/tests/test-ressources/split-archive-corrupted/large-folder.part2.lst
+++ b/tests/test-ressources/split-archive-corrupted/large-folder.part2.lst
@@ -1,0 +1,1 @@
+large-folder/file_a.txt

--- a/tests/test-ressources/split-archive-corrupted/large-folder.part3.lst
+++ b/tests/test-ressources/split-archive-corrupted/large-folder.part3.lst
@@ -1,0 +1,1 @@
+large-folder/file_b.txt

--- a/tests/test-ressources/split-archive-incomplete/large-folder.part1.lst
+++ b/tests/test-ressources/split-archive-incomplete/large-folder.part1.lst
@@ -1,0 +1,2 @@
+large-folder/subfolder
+large-folder/subfolder/file_c.txt

--- a/tests/test-ressources/split-archive-incomplete/large-folder.part2.lst
+++ b/tests/test-ressources/split-archive-incomplete/large-folder.part2.lst
@@ -1,0 +1,1 @@
+large-folder/file_a.txt

--- a/tests/test-ressources/split-archive/large-folder.part1.lst
+++ b/tests/test-ressources/split-archive/large-folder.part1.lst
@@ -1,0 +1,2 @@
+large-folder/subfolder
+large-folder/subfolder/file_c.txt

--- a/tests/test-ressources/split-archive/large-folder.part2.lst
+++ b/tests/test-ressources/split-archive/large-folder.part2.lst
@@ -1,0 +1,1 @@
+large-folder/file_a.txt

--- a/tests/test-ressources/split-archive/large-folder.part3.lst
+++ b/tests/test-ressources/split-archive/large-folder.part3.lst
@@ -1,0 +1,1 @@
+large-folder/file_b.txt

--- a/tests/test-ressources/split-encrypted-archive-incomplete/large-folder.part1.lst
+++ b/tests/test-ressources/split-encrypted-archive-incomplete/large-folder.part1.lst
@@ -1,0 +1,2 @@
+large-folder/subfolder
+large-folder/subfolder/file_c.txt

--- a/tests/test-ressources/split-encrypted-archive-incomplete/large-folder.part2.lst
+++ b/tests/test-ressources/split-encrypted-archive-incomplete/large-folder.part2.lst
@@ -1,0 +1,1 @@
+large-folder/file_a.txt

--- a/tests/test-ressources/split-encrypted-archive/large-folder.part1.lst
+++ b/tests/test-ressources/split-encrypted-archive/large-folder.part1.lst
@@ -1,0 +1,2 @@
+large-folder/subfolder
+large-folder/subfolder/file_c.txt

--- a/tests/test-ressources/split-encrypted-archive/large-folder.part2.lst
+++ b/tests/test-ressources/split-encrypted-archive/large-folder.part2.lst
@@ -1,0 +1,1 @@
+large-folder/file_a.txt

--- a/tests/test-ressources/split-encrypted-archive/large-folder.part3.lst
+++ b/tests/test-ressources/split-encrypted-archive/large-folder.part3.lst
@@ -1,0 +1,1 @@
+large-folder/file_b.txt

--- a/tests/test-ressources/symlink-archive/symlink-folder.lst
+++ b/tests/test-ressources/symlink-archive/symlink-folder.lst
@@ -1,0 +1,7 @@
+symlink-folder
+symlink-folder/file1.txt
+symlink-folder/invalid_link
+symlink-folder/folder-in-archive
+symlink-folder/invalid_link_abs
+symlink-folder/folder-in-archive/file2.txt
+symlink-folder/folder-in-archive/link.txt

--- a/tests/units/test_splitter.py
+++ b/tests/units/test_splitter.py
@@ -51,7 +51,7 @@ def assert_archiving_splitting(path, max_size, expected_result):
 
 def relative_strings_from_archives_list(archives, relative_to_path):
     # Return a list in order to assert length in test
-    return [relatative_string_from_path_list(paths, relative_to_path) for paths in archives]
+    return [relatative_string_from_path_list(paths[0], relative_to_path) for paths in archives]
 
 
 def relatative_string_from_path_list(path_list, relative_to_path):


### PR DESCRIPTION
* modified the splitter, such that not only the splits, but a complete file listing (including empty directories and recursively parsed directories)
* streamlined archiver.py to make the processing of split and unsplit archives more alike (first step towards this, integration can go further)
* archive creation now uses the complete file list and not the checksum file
* the additional *.lst files have been added to all relevant tests
* symlinks to directories are now treated as files
* creation of tar archives now uses the option "--no-recursion”
* renamed "create_filelist_and_hashs” into “create_filelist_and_hashes"